### PR TITLE
mta: fix telekinetic room

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mta/telekinetic/TelekineticRoom.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mta/telekinetic/TelekineticRoom.java
@@ -44,6 +44,7 @@ import net.runelite.api.GameState;
 import net.runelite.api.GroundObject;
 import net.runelite.api.NPC;
 import net.runelite.api.NpcID;
+import net.runelite.api.NullNpcID;
 import net.runelite.api.NullObjectID;
 import net.runelite.api.Perspective;
 import net.runelite.api.WallObject;
@@ -66,7 +67,7 @@ import net.runelite.client.plugins.mta.MTARoom;
 @Slf4j
 public class TelekineticRoom extends MTARoom
 {
-	private static final int MAZE_GUARDIAN_MOVING = 6778;
+	private static final int MAZE_GUARDIAN_MOVING = NullNpcID.NULL_6778;
 	private static final int TELEKINETIC_WALL = NullObjectID.NULL_10755;
 	private static final int TELEKINETIC_FINISH = NullObjectID.NULL_23672;
 
@@ -193,7 +194,7 @@ public class TelekineticRoom extends MTARoom
 	{
 		NPC npc = event.getNpc();
 
-		if (npc.getId() == NpcID.MAZE_GUARDIAN)
+		if (npc.getId() == NpcID.MAZE_GUARDIAN || npc.getId() == MAZE_GUARDIAN_MOVING)
 		{
 			guardian = npc;
 		}


### PR DESCRIPTION
Due to changes to the spawn events the moving guardian now has its own events